### PR TITLE
Delete files from destination when removed from source

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ node {
     }
 
     stage('Bundle') {
-        sh "aws s3 sync --acl public-read vendor s3://${env.S3_CDN_BUCKET}/vendor/"
+        sh "aws s3 sync --delete --acl public-read vendor s3://${env.S3_CDN_BUCKET}/vendor/"
     }
 }


### PR DESCRIPTION
Pass the `delete` switch to the `sync` command to remove files that are present in the destination but not in the source.
