### PR TITLE
feature/cache-control-max-age

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ node {
     }
 
     stage('Bundle') {
-        sh "aws s3 sync --delete --acl public-read vendor s3://${env.S3_CDN_BUCKET}/vendor/"
+        sh "aws s3 sync --delete --acl public-read --cache-control max-age=1209600 vendor s3://${env.S3_CDN_BUCKET}/vendor/"
     }
 }


### PR DESCRIPTION
Set `Cache-Control: max-age` header for vendor objects. This is initially set to `1209600` seconds (2 weeks).