### PR TITLE
Modify CODEOWNERS to .github folder only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @ONSdigital/dissemination-open-sauce @ONSdigital/dissemination-platform @ONSdigital/dissemination-cms
+# The below indicates the code owners of this repo without auto-assigning PRs to the team
+
+.github/* @ONSdigital/dissemination-open-sauce @ONSdigital/dissemination-platform @ONSdigital/dissemination-cms


### PR DESCRIPTION
### What

Switched to .github folder only. 

### How to review

Check looks ok and in line with approach to codeowners for multiple teams

### Who can review

Not me. 