### PR TITLE
Change codeowners to all dissemination

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # The below indicates the code owners of this repo without auto-assigning PRs to the team
 
-.github/* @ONSdigital/dissemination-open-sauce @ONSdigital/dissemination-platform @ONSdigital/dissemination-cms
+.github/* @ONSdigital/dissemination


### PR DESCRIPTION
### What

Changed codeowners to all dissemination as this is an asset shared by all dissemination.

### How to review

Check looks ok, appropriate change

### Who can review

Not me. 